### PR TITLE
PR1: User authentication with Rails 8 generator

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle update:*)",
+      "Bash(bundle exec rspec:*)",
+      "Bash(gem search:*)",
+      "WebFetch(domain:flowbite-react.com)",
+      "Bash(rbs-inline:*)",
+      "WebSearch",
+      "Bash(bundle exec:*)",
+      "Bash(gem list:*)",
+      "Bash(head -5 /Users/ilia/Devel/cibc-visa-import/data/*.csv)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Banking App
+
+## Deployment
+
+Deployed via Kamal to 10.0.0.218. Migrations are not run automatically on deploy.
+
+### Two-phase deploy for migrations
+
+Avoid coupling schema changes with code that depends on them in a single deploy. Instead:
+
+1. Deploy code that works with both old and new schema (e.g., add a column, but don't remove or rename the old one yet)
+2. Run migration: `kamal app exec --reuse 'bin/rails db:migrate'`
+3. Deploy code that relies on the new schema
+4. Clean up the old column in a later migration
+
+This prevents breakage if the deploy fails after the migration has already run.

--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,5 @@ group :development do
   gem 'rbs', '~> 4.0', require: false
   gem 'web-console'
 end
+
+gem "bcrypt", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       activesupport (>= 6.0.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.0)
     bindex (0.8.1)
@@ -147,7 +148,6 @@ GEM
       net-smtp
     marcel (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (6.0.3)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -167,9 +167,6 @@ GEM
       net-protocol
     net-ssh (7.3.1)
     nio4r (2.7.5)
-    nokogiri (1.19.2)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
@@ -326,11 +323,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
-  ruby
   x86_64-linux
 
 DEPENDENCIES
   annotaterb (~> 4.20.0)
+  bcrypt (~> 3.1)
   bootsnap
   brakeman
   bundler-audit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 # rbs_inline: enabled
 
 class ApplicationController < ActionController::API
+  include ActionController::Cookies
+  include Authentication
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -38,7 +38,7 @@ module Authentication
     def verify_origin
       return if request.get? || request.head? || request.options?
 
-      allowed = ENV["CORS_ORIGINS"] || "http://localhost:3000"
+      allowed = ENV["CORS_ORIGINS"] || "http://localhost:3001"
       origin = request.headers["Origin"]
 
       head :forbidden unless origin.present? && origin == allowed

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,64 @@
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_authentication
+    before_action :verify_origin
+  end
+
+  class_methods do
+    def allow_unauthenticated_access(**options)
+      skip_before_action :require_authentication, **options
+    end
+  end
+
+  private
+    def authenticated?
+      resume_session
+    end
+
+    def require_authentication
+      resume_session || request_authentication
+    end
+
+    def resume_session
+      Current.session ||= find_session_by_cookie
+    end
+
+    def find_session_by_cookie
+      if cookies.signed[:session_id]
+        Session.find_by(id: cookies.signed[:session_id], created_at: 30.days.ago..)
+      end
+    end
+
+    def request_authentication
+      head :unauthorized
+    end
+
+    def verify_origin
+      return if request.get? || request.head? || request.options?
+
+      allowed = ENV["CORS_ORIGINS"] || "http://localhost:3000"
+      origin = request.headers["Origin"]
+
+      head :forbidden unless origin.present? && origin == allowed
+    end
+
+    def start_new_session_for(user)
+      user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
+        Current.session = session
+        cookies.signed[:session_id] = {
+          value: session.id,
+          expires: 30.days.from_now,
+          httponly: true,
+          secure: Rails.env.production?,
+          same_site: Rails.env.production? ? :none : :lax
+        }
+      end
+    end
+
+    def terminate_session
+      Current.session.destroy
+      cookies.delete(:session_id)
+    end
+end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -15,8 +15,7 @@ class GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      # Query context goes here, for example:
-      # current_user: current_user,
+      current_user: Current.user,
     }
     result = BankingSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,20 @@
+class PasswordsController < ApplicationController
+  allow_unauthenticated_access
+  before_action :set_user_by_token, only: :update
+
+  def update
+    if @user.update(params.permit(:password, :password_confirmation))
+      @user.sessions.destroy_all
+      render json: { message: "Password has been reset." }, status: :ok
+    else
+      render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def set_user_by_token
+      @user = User.find_by_password_reset_token!(params[:token])
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      render json: { error: "Password reset link is invalid or has expired." }, status: :unprocessable_entity
+    end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,6 @@
 class RegistrationsController < ApplicationController
   allow_unauthenticated_access only: :create
+  rate_limit to: 5, within: 10.minutes, only: :create, with: -> { render json: { error: "Try again later." }, status: :too_many_requests }
 
   def create
     user = User.new(params.permit(:email_address, :password))

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,21 @@
+class RegistrationsController < ApplicationController
+  allow_unauthenticated_access only: :create
+
+  def create
+    user = User.new(params.permit(:email_address, :password))
+    if user.save
+      start_new_session_for user
+      render json: { user: user_json(user) }, status: :created
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::RecordNotUnique
+    render json: { errors: [ "Email address has already been taken" ] }, status: :unprocessable_entity
+  end
+
+  private
+
+  def user_json(user)
+    { id: user.id, email_address: user.email_address }
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,28 @@
+class SessionsController < ApplicationController
+  allow_unauthenticated_access only: :create
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { render json: { error: "Try again later." }, status: :too_many_requests }
+
+  def show
+    render json: { user: user_json(Current.user) }
+  end
+
+  def create
+    if user = User.authenticate_by(params.permit(:email_address, :password))
+      start_new_session_for user
+      render json: { user: user_json(user) }, status: :created
+    else
+      render json: { error: "Invalid email address or password." }, status: :unauthorized
+    end
+  end
+
+  def destroy
+    terminate_session
+    render json: { message: "Logged out." }, status: :ok
+  end
+
+  private
+
+  def user_json(user)
+    { id: user.id, email_address: user.email_address }
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :session
+  delegate :user, to: :session, allow_nil: true
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: sessions
+#
+#  id         :bigint           not null, primary key
+#  ip_address :string
+#  token      :string           not null
+#  user_agent :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_sessions_on_token    (token) UNIQUE
+#  index_sessions_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Session < ApplicationRecord
+  belongs_to :user
+
+  before_create { self.token = SecureRandom.urlsafe_base64(32) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id              :bigint           not null, primary key
+#  email_address   :string           not null
+#  password_digest :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email_address  (email_address) UNIQUE
+#
+class User < ApplicationRecord
+  has_secure_password
+  has_many :sessions, dependent: :destroy
+
+  normalizes :email_address, with: ->(e) { e.strip.downcase }
+
+  validates :email_address, presence: true, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,5 @@ class User < ApplicationRecord
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
   validates :email_address, presence: true, uniqueness: true
+  validates :password, length: { minimum: 8 }, if: -> { password.present? }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,9 @@ module Banking
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Add cookie middleware back for httpOnly session cookies
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,10 +7,11 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['CORS_ORIGINS'] || '*'
+    origins ENV['CORS_ORIGINS'] || 'http://localhost:3000'
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['CORS_ORIGINS'] || 'http://localhost:3000'
+    origins ENV['CORS_ORIGINS'] || 'http://localhost:3001'
 
     resource '*',
       headers: :any,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  resource :session, only: %i[show create destroy]
+  resource :registration, only: :create
+  resources :passwords, param: :token
   get 'up' => 'rails/health#show', as: :rails_health_check
 
   post '/graphql', to: 'graphql#execute'

--- a/db/migrate/20260414160041_create_users.rb
+++ b/db/migrate/20260414160041_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :email_address, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+    add_index :users, :email_address, unique: true
+  end
+end

--- a/db/migrate/20260414160042_create_sessions.rb
+++ b/db/migrate/20260414160042_create_sessions.rb
@@ -1,0 +1,14 @@
+class CreateSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token, null: false
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+
+    add_index :sessions, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_22_222234) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_14_160042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,5 +42,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_22_222234) do
     t.index ["credit_card_transaction_id"], name: "index_notes_on_credit_card_transaction_id", unique: true
   end
 
+  create_table "sessions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.string "token", null: false
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.bigint "user_id", null: false
+    t.index ["token"], name: "index_sessions_on_token", unique: true
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email_address", null: false
+    t.string "password_digest", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+  end
+
   add_foreign_key "notes", "credit_card_transactions"
+  add_foreign_key "sessions", "users"
 end

--- a/docs/flinks-auto-import-with-auth.md
+++ b/docs/flinks-auto-import-with-auth.md
@@ -1,0 +1,551 @@
+# Flinks CIBC Transaction Auto-Import with User Authentication
+
+## Conventions
+
+- **No co-authored-by lines** in commit messages or PR descriptions
+
+## Context
+
+Currently, importing CIBC/Rogers credit card transactions requires manually downloading CSV files from online banking. The goal is to:
+1. Add user authentication so multiple users can register and log in
+2. Isolate transactions per user
+3. Allow each user to connect their own CIBC account via Flinks
+4. Automatically import transactions on a configurable recurring schedule
+
+Three projects are involved:
+- **banking** (`~/Devel/banking`) — Rails 8.1 API, GraphQL + REST, PostgreSQL
+- **banking-react-apollo** (`~/Devel/banking-react-apollo`) — React 19 + Apollo Client 4 frontend
+- **cibc-visa-import** (`~/Devel/cibc-visa-import`) — current manual CSV pipeline (to be superseded)
+
+---
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────┐
+│  Frontend (React + Apollo)                   │
+│  ┌────────────┐ ┌──────────────┐ ┌────────┐ │
+│  │ Login /    │ │ Flinks       │ │ Import │ │
+│  │ Register   │ │ Connect      │ │ Status │ │
+│  └─────┬──────┘ └──────┬───────┘ └───┬────┘ │
+└────────┼───────────────┼─────────────┼───────┘
+  Bearer │ token  loginId│      GraphQL│
+         ▼               ▼             ▼
+┌──────────────────────────────────────────────┐
+│  Backend (Rails 8.1 API)                     │
+│                                              │
+│  Auth: Rails 8 built-in (session tokens)     │
+│  POST /registration, POST /session           │
+│                                              │
+│  Flinks::Client ─► Flinks::TransactionImporter│
+│       │                     │                │
+│  FlinksImportJob (Solid Queue, daily 6am)    │
+│                             ▼                │
+│  ┌──────────────────────────────────────┐    │
+│  │ PostgreSQL                           │    │
+│  │ users ──< flinks_connections         │    │
+│  │ users ──< credit_card_transactions   │    │
+│  │            ──< notes                 │    │
+│  │            ──< credits_debits        │    │
+│  └──────────────────────────────────────┘    │
+└──────────────────────────────────────────────┘
+```
+
+---
+
+## Part 1: User Authentication
+
+### Approach: Rails 8 built-in authentication generator (`--api`)
+
+**Why the built-in generator:** Rails 8.1 ships with `bin/rails generate authentication --api` which creates a complete token-based auth system. It uses server-side session tokens (stored in a `sessions` table) sent via `Authorization: Bearer <token>` headers — works identically with Apollo Client. No custom JWT code to maintain.
+
+**Why not JWT:** The generator provides revocable tokens (delete the session row), session tracking (IP, user agent), and password reset — all out of the box. JWT requires a custom implementation, can't be revoked without a blocklist, and needs secret key management.
+
+**Why not Devise:** Overkill for this app — one user table, no OAuth, no confirmable/lockable.
+
+### What the generator creates
+
+| File | Purpose |
+|------|---------|
+| `app/models/user.rb` | `has_secure_password`, `has_many :sessions`, `normalizes :email_address` |
+| `app/models/session.rb` | Token-based session record (user_id, ip_address, user_agent) |
+| `app/models/current.rb` | Thread-local `Current.user` / `Current.session` |
+| `app/controllers/concerns/authentication.rb` | `require_authentication`, `current_user`, token lookup via `Authorization: Bearer` |
+| `app/controllers/sessions_controller.rb` | `POST /session` (login), `DELETE /session` (logout) |
+| `app/controllers/passwords_controller.rb` | Password reset endpoints |
+| `db/migrate/*_create_users.rb` | `email_address` (unique), `password_digest` |
+| `db/migrate/*_create_sessions.rb` | `user_id`, `ip_address`, `user_agent` |
+
+### What we add on top
+
+| File | Purpose |
+|------|---------|
+| `app/controllers/registrations_controller.rb` | `POST /registration` — create user + session, return token |
+
+The generator does not include registration. We add a single controller for that.
+
+### Database tables
+
+```sql
+-- Created by generator
+CREATE TABLE users (
+  id               bigserial PRIMARY KEY,
+  email_address    varchar NOT NULL,
+  password_digest  varchar NOT NULL,
+  created_at       timestamptz NOT NULL,
+  updated_at       timestamptz NOT NULL,
+  UNIQUE(email_address)
+);
+
+CREATE TABLE sessions (
+  id         bigserial PRIMARY KEY,
+  user_id    bigint NOT NULL REFERENCES users(id),
+  ip_address varchar,
+  user_agent varchar,
+  created_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL
+);
+```
+
+### Auth in GraphQL + REST
+
+- The `Authentication` concern is included in `ApplicationController` — all controllers get `require_authentication` and `current_user`
+- `GraphqlController#execute` passes `Current.user` into GraphQL context
+- All resolvers scope queries through `context[:current_user]`
+- All REST controller actions scope through `Current.user`
+- Missing/invalid token → 401 response (handled by the concern)
+
+### Frontend files
+
+| File | Purpose |
+|------|---------|
+| `src/components/LoginPage.jsx` | Email + password form, stores session token in localStorage |
+| `src/components/RegisterPage.jsx` | Registration form |
+| `src/hooks/useAuth.js` | Auth state context — `login()`, `logout()`, `isAuthenticated` |
+
+**Apollo Client change** (`src/index.jsx`):
+```js
+import { setContext } from '@apollo/client/link/context';
+
+const authLink = setContext((_, { headers }) => ({
+  headers: {
+    ...headers,
+    authorization: localStorage.getItem('token')
+      ? `Bearer ${localStorage.getItem('token')}`
+      : '',
+  },
+}));
+
+const client = new ApolloClient({
+  link: authLink.concat(httpLink),
+  cache: new InMemoryCache(),
+});
+```
+
+**Routing:** Add `react-router-dom` for login/register/dashboard pages. Unauthenticated users → login page. 401 from API → clear token, redirect to login.
+
+---
+
+## Part 2: Per-User Transaction Isolation
+
+### Approach: `user_id` column on `credit_card_transactions`
+
+No `default_scope` (Rails footgun). Explicit scoping in resolvers and controllers via `current_user.credit_card_transactions`.
+
+`notes` and `credits_debits` are already scoped through their FK to `credit_card_transactions` — no `user_id` needed on those tables.
+
+### Unique index changes
+
+Current indexes reject duplicates globally. Two users with the same transaction would conflict. Replace with user-scoped indexes:
+
+```sql
+-- Drop existing
+DROP INDEX credit_card_transactions_debits_unique_key;
+DROP INDEX credit_card_transactions_credits_unique_key;
+
+-- Create user-scoped
+CREATE UNIQUE INDEX credit_card_transactions_debits_unique_key
+  ON credit_card_transactions (user_id, tx_date, details, debit) WHERE credit IS NULL;
+CREATE UNIQUE INDEX credit_card_transactions_credits_unique_key
+  ON credit_card_transactions (user_id, tx_date, details, credit) WHERE debit IS NULL;
+```
+
+### Migration strategy (two-phase deploy per CLAUDE.md)
+
+**Phase 1:** Add `user_id` as nullable, create `users` table
+- Migration: `create_table :users`
+- Migration: `add_reference :credit_card_transactions, :user, null: true`
+- Deploy — existing code still works (nullable column, no scoping yet)
+
+**Phase 2:** Seed admin user, backfill, enforce NOT NULL, replace indexes
+- Rake task: create admin user, `UPDATE credit_card_transactions SET user_id = <admin_id>`
+- Migration: `change_column_null :credit_card_transactions, :user_id, false`
+- Migration: drop old indexes, create user-scoped indexes
+- Deploy with auth enforcement + scoped queries
+
+### GraphQL resolver changes
+
+`app/graphql/types/query_type.rb` — scope through current_user:
+```ruby
+def credit_card_transactions(**options)
+  scope = context[:current_user].credit_card_transactions
+    .where(tx_date: 12.months.ago..)
+  # ... existing sort/filter logic
+end
+```
+
+Mutations (`update_credit_card_transaction`, `create_note`) — verify ownership:
+```ruby
+tx = context[:current_user].credit_card_transactions.find_by!(id: id)
+```
+
+REST controllers — same pattern with `current_user.credit_card_transactions`.
+
+---
+
+## Part 3: Flinks Integration
+
+### Database: `flinks_connections` table
+
+```sql
+CREATE TABLE flinks_connections (
+  id            bigserial PRIMARY KEY,
+  user_id       bigint NOT NULL REFERENCES users(id),
+  institution   text NOT NULL,
+  login_id      text NOT NULL,     -- encrypted at rest
+  request_id    text,              -- encrypted at rest
+  last_synced_at timestamptz,
+  status        text NOT NULL DEFAULT 'active',
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, institution)
+);
+```
+
+**Token encryption:** Use Rails 8 `encrypts` attribute:
+```ruby
+class FlinksConnection < ApplicationRecord
+  belongs_to :user
+  encrypts :login_id
+  encrypts :request_id
+end
+```
+
+Keys generated via `bin/rails db:encryption:init`, stored in `config/credentials.yml.enc`.
+
+### Flinks HTTP Client
+
+**`app/services/flinks/client.rb`** — raw `Net::HTTP` (not the archived gem):
+- `authorize(login_id:)` → exchange for access token
+- `fetch_transactions(account_id:, from:, to:)` → GET transactions
+
+**`app/services/flinks/errors.rb`** — `ApiError`, `AuthenticationError`, `RateLimitError`
+
+### Transaction Importer
+
+**`app/services/flinks/transaction_importer.rb`**:
+1. Accept a `FlinksConnection` record
+2. Fetch transactions (default: last 7 days)
+3. Transform:
+   - `TransactionDate` → `tx_date`
+   - `Description` → `details`
+   - Positive amount → `debit = (amount * 100).round`, `credit = NULL`
+   - Negative amount → `credit = (amount.abs * 100).round`, `debit = NULL`
+   - Connection's card info → `card_number`
+   - Connection's `user_id` → `user_id`
+4. `CreditCardTransaction.insert_all(records)` — unique indexes handle dedup via ON CONFLICT
+5. Return `{ imported: N, skipped: N }`
+
+### Recurring Job
+
+**`app/jobs/flinks_import_job.rb`**:
+```ruby
+class FlinksImportJob < ApplicationJob
+  queue_as :default
+  retry_on Flinks::ApiError, wait: :polynomially_longer, attempts: 5
+  discard_on Flinks::AuthenticationError
+
+  def perform(days_back: 7)
+    FlinksConnection.where(status: 'active').find_each do |conn|
+      Flinks::TransactionImporter.new(conn).import(days_back:)
+    end
+  end
+end
+```
+
+**`config/recurring.yml`**:
+```yaml
+flinks_import:
+  class: FlinksImportJob
+  schedule: every day at 6am America/Toronto
+  args:
+    days_back: 7
+```
+
+### Solid Queue setup
+
+1. Uncomment `require "active_job/railtie"` in `config/application.rb`
+2. Add `gem "solid_queue"` to Gemfile
+3. `bin/rails solid_queue:install`
+4. Set `config.active_job.queue_adapter = :solid_queue` in production.rb
+5. Add `SOLID_QUEUE_IN_PUMA: "1"` to `config/deploy.yml` env
+
+### Frontend: Flinks Connect
+
+**`src/components/FlinksConnect.jsx`** — modal with Flinks Connect iframe widget for one-time bank auth. On success, sends `loginId` to backend.
+
+**`src/components/ImportStatus.jsx`** — shows last sync time, connection status, "Sync Now" button.
+
+### GraphQL additions
+
+- Query: `flinksConnections` → list user's connected accounts
+- Query: `flinksImportStatus` → last run, next scheduled
+- Mutation: `createFlinksConnection(loginId, institution)` → store connection
+- Mutation: `triggerFlinksImport(daysBack)` → enqueue job on demand
+- Mutation: `deleteFlinksConnection(id)` → remove connection
+
+### Polling over webhooks
+
+The backend runs without SSL (`proxy: ssl: false` in deploy.yml). Flinks webhooks require HTTPS. Daily polling with 7-day overlap + dedup indexes is simpler and sufficient.
+
+---
+
+## Development Approach: Test-Driven Development
+
+Each feature follows a strict red-green-refactor cycle:
+1. **Red:** Write a failing test that specifies the desired behavior
+2. **Green:** Write the minimum code to make the test pass
+3. **Refactor:** Clean up while keeping tests green
+
+Within each PR, the commit history should reflect this rhythm — test commits precede implementation commits. Every behavior is specified by a test before the code exists.
+
+### Testing Philosophy
+
+1. **Don't test upstream behavior.** If Rails, ActiveRecord, or a gem already tests it (validations, associations, `has_secure_password`, `normalizes`), don't write a spec for it. Only test custom behavior and integration contracts.
+2. **Minimize mocking/stubbing.** Use real objects, real database, real ActiveRecord queries. Mocks hide bugs where the mock diverges from reality. Only mock when there is no practical alternative (e.g., time-dependent behavior with `travel_to`).
+3. **VCR cassettes for network interaction.** All tests that hit the Flinks API record real HTTP interactions as VCR cassettes (`spec/cassettes/`). Tests replay cassettes on subsequent runs — no stubs, no hand-crafted response hashes. Record new cassettes by running tests with `VCR_RECORD=new_episodes`. Add `gem 'vcr'` and `gem 'webmock'` to the test group.
+4. **Real database, no mocked queries.** Integration specs hit PostgreSQL. This catches issues with unique indexes, constraints, and scoping that mocks would hide.
+5. **Fixtures for test data.** Follow the existing pattern in `spec/fixtures/`. Add `users.yml` and `flinks_connections.yml` fixtures.
+
+### Backend TDD (RSpec)
+
+For each backend feature, write tests first in this order:
+1. **Request/integration specs** — define the API contract (endpoints, status codes, response shape)
+2. **Service specs** — define inputs, outputs, and error cases (VCR cassettes for Flinks HTTP)
+3. **GraphQL specs** — define query/mutation behavior (following existing patterns in `spec/graphql/`)
+4. **Model specs** — only for custom logic (computed fields, custom scopes, non-trivial methods). Skip for standard Rails declarations.
+
+### Frontend TDD (Vitest)
+
+For each frontend feature, write tests first:
+1. **Hook tests** — define auth state transitions (`useAuth` login/logout/token expiry)
+2. **Component tests** — define rendering and interaction behavior (login form submission, error display, protected route redirect)
+
+The project uses Vitest (`vitest run`). Add `@testing-library/react` for component tests.
+
+---
+
+## Implementation Sequence (Stacked PRs)
+
+Each PR targets the branch of the previous PR, forming a dependent chain. Merge bottom-up (PR1 first). Each PR is independently reviewable and deployable following the two-phase deploy protocol in CLAUDE.md.
+
+```
+main
+ └─ PR1: feat/user-auth-backend
+     └─ PR2: feat/transaction-isolation
+         └─ PR3: feat/auth-frontend
+             └─ PR4: feat/flinks-connection
+                 └─ PR5: feat/flinks-import-pipeline
+                     └─ PR6: feat/flinks-frontend
+```
+
+### PR1: `feat/user-auth-backend` → `main`
+**Users + session-token authentication (backend only)**
+
+Tests first (red):
+1. `spec/requests/auth_spec.rb` — register returns 201 + token; login returns 200 + token; login with wrong password returns 401; register with duplicate email returns 422; request without token returns 401; logout invalidates session
+
+Then implementation (green):
+3. Run `bin/rails generate authentication` — creates User, Session, Current models, Authentication concern, SessionsController, PasswordsController, migrations
+4. `app/controllers/registrations_controller.rb` — `POST /registration` (generator doesn't include signup)
+5. `config/routes.rb` — add `resource :registration, only: :create`
+6. Pass `Current.user` into GraphQL context in `graphql_controller.rb`
+
+- **Deploy note:** Auth endpoints exist but nothing requires auth yet. Existing API continues to work unauthenticated.
+
+### PR2: `feat/transaction-isolation` → `feat/user-auth-backend`
+**Per-user transaction scoping (backend only)**
+
+Tests first (red):
+1. `spec/graphql/queries/credit_card_transactions_query_spec.rb` — update existing specs: user A cannot see user B's transactions; unauthenticated request returns error
+2. `spec/graphql/mutations/update_credit_card_transaction_mutation_spec.rb` — update: cannot update another user's transaction
+3. `spec/graphql/mutations/create_note_mutation_spec.rb` — update: cannot annotate another user's transaction
+4. `spec/requests/credit_card_transactions_spec.rb` — REST endpoints return only current user's transactions
+5. `spec/models/credit_card_transaction_spec.rb` — user-scoped uniqueness (same tx for different users is allowed, same tx for same user is rejected)
+
+Then implementation (green):
+6. Migration: add nullable `user_id` FK to `credit_card_transactions`
+7. `lib/tasks/admin.rake` — seed admin user, backfill existing transactions
+8. Migration: enforce `user_id` NOT NULL, replace unique indexes with user-scoped versions
+9. Scope all GraphQL resolvers (`query_type.rb`) through `context[:current_user]`
+10. Scope all REST controller actions through `current_user`
+11. Scope mutations — verify ownership
+12. Pass `current_user` into GraphQL context in `graphql_controller.rb`
+13. Require authentication on all endpoints (except `/auth/*`)
+14. Lock down CORS origins in `cors.rb`
+15. Update fixtures to include `user_id`
+
+- **Deploy note:** Two-phase — deploy migration + backfill first, then deploy auth enforcement. After this PR, the API requires a JWT.
+
+### PR3: `feat/auth-frontend` → `feat/transaction-isolation`
+**Login/register UI + protected routes (frontend)**
+
+Tests first (red):
+1. `src/hooks/useAuth.test.js` — login stores session token, logout calls DELETE /session and clears token, isAuthenticated reflects state
+2. `src/components/LoginPage.test.jsx` — renders form, submits credentials to POST /session, shows error on failure, redirects on success
+3. `src/components/RegisterPage.test.jsx` — renders form, submits to POST /registration, shows error on duplicate email
+
+Then implementation (green):
+4. Add `react-router-dom`, `@testing-library/react` dependencies
+5. `src/hooks/useAuth.js` — auth context, `login()` (POST /session), `register()` (POST /registration), `logout()` (DELETE /session), `isAuthenticated`
+6. `src/components/LoginPage.jsx` — email + password form
+7. `src/components/RegisterPage.jsx` — registration form
+8. `src/index.jsx` — Apollo `setContext` auth link with Bearer token, error link for 401 → redirect
+9. `src/components/App.jsx` — route setup, protected routes
+10. `src/components/AppNavbar.jsx` — user email display, logout button
+
+- **Deploy note:** Can deploy frontend before or after PR2, but the app will require login once both are live.
+
+### PR4: `feat/flinks-connection` → `feat/auth-frontend`
+**Flinks account connection (backend + frontend)**
+
+Tests first (red):
+1. `spec/services/flinks/client_spec.rb` (VCR cassettes) — authorize returns request_id; fetch_transactions returns parsed transactions; handles 401 with AuthenticationError; handles 429 with RateLimitError; handles network timeout with ApiError
+2. `spec/graphql/mutations/create_flinks_connection_mutation_spec.rb` — stores connection for current user; rejects duplicate institution
+3. `spec/graphql/mutations/delete_flinks_connection_mutation_spec.rb` — deletes own connection; cannot delete another user's connection
+
+Then implementation (green):
+5. Migration: create `flinks_connections` table with encrypted columns
+6. `app/models/flinks_connection.rb` — `belongs_to :user`, `encrypts :login_id, :request_id`
+7. Generate Active Record encryption keys via `bin/rails db:encryption:init`
+8. `app/services/flinks/client.rb` — `Net::HTTP` wrapper for Flinks API
+9. `app/services/flinks/errors.rb` — error classes
+10. `app/graphql/types/flinks_connection_type.rb`
+11. `app/graphql/mutations/create_flinks_connection.rb` — store loginId from Flinks Connect
+12. `app/graphql/mutations/delete_flinks_connection.rb` — remove connection
+13. `src/components/FlinksConnect.jsx` — Flinks Connect iframe widget in modal
+
+- **Deploy note:** Users can now connect their CIBC account. No imports yet.
+
+### PR5: `feat/flinks-import-pipeline` → `feat/flinks-connection`
+**Automated transaction import (backend)**
+
+Tests first (red):
+1. `spec/services/flinks/transaction_importer_spec.rb` (VCR cassettes for API calls, real DB for insert/dedup) — transforms positive amount to debit in cents; transforms negative amount to credit in cents; sets user_id from connection; skips duplicates via ON CONFLICT; returns imported/skipped counts; handles empty response; handles partial failures
+2. `spec/jobs/flinks_import_job_spec.rb` — iterates active connections; skips inactive connections; retries on ApiError; discards on AuthenticationError
+3. `spec/graphql/mutations/trigger_flinks_import_mutation_spec.rb` — enqueues job for current user
+4. `spec/graphql/queries/flinks_import_status_query_spec.rb` — returns last sync time and status
+
+Then implementation (green):
+5. `app/services/flinks/transaction_importer.rb` — fetch, transform, insert
+6. `app/jobs/flinks_import_job.rb` — iterates active connections, imports transactions
+7. `config/recurring.yml` — daily 6am ET schedule
+8. Enable Solid Queue: uncomment `active_job/railtie`, add `solid_queue` gem, install, configure
+9. `config/deploy.yml` — add `SOLID_QUEUE_IN_PUMA` env var
+10. `app/graphql/types/flinks_import_status_type.rb`
+11. `app/graphql/mutations/trigger_flinks_import.rb` — on-demand sync
+12. GraphQL query: `flinksImportStatus` — last run, next scheduled
+
+- **Deploy note:** Two-phase — deploy Solid Queue migration first, then deploy code. After this, imports run automatically.
+
+### PR6: `feat/flinks-frontend` → `feat/flinks-import-pipeline`
+**Import status UI + manual trigger (frontend)**
+
+Tests first (red):
+1. `src/components/ImportStatus.test.jsx` — renders last sync time; renders "never" when no syncs; "Sync Now" button triggers mutation; shows loading state during sync
+2. `src/components/FlinksConnect.test.jsx` — renders iframe; calls mutation on success callback; shows error on failure
+
+Then implementation (green):
+3. `src/components/ImportStatus.jsx` — last sync time, connection status, "Sync Now" button
+4. Integrate into App.jsx / dashboard view
+5. Connection management UI (list connected accounts, disconnect)
+
+- **Deploy note:** Pure frontend, safe to deploy anytime after PR5.
+
+---
+
+## Files Summary
+
+### New files (banking)
+| File | Purpose |
+|------|---------|
+| `app/models/user.rb` | `has_secure_password`, associations (generated) |
+| `app/models/session.rb` | Token-based session record (generated) |
+| `app/models/current.rb` | Thread-local `Current.user` (generated) |
+| `app/controllers/concerns/authentication.rb` | `require_authentication`, token lookup (generated) |
+| `app/controllers/sessions_controller.rb` | Login/logout (generated) |
+| `app/controllers/passwords_controller.rb` | Password reset (generated) |
+| `app/controllers/registrations_controller.rb` | User signup (custom) |
+| `db/migrate/*_create_users.rb` | Users table (generated) |
+| `db/migrate/*_create_sessions.rb` | Sessions table (generated) |
+| `db/migrate/*_add_user_id_to_credit_card_transactions.rb` | User FK (nullable) |
+| `db/migrate/*_enforce_user_id_and_update_indexes.rb` | NOT NULL + scoped indexes |
+| `db/migrate/*_create_flinks_connections.rb` | Flinks tokens table |
+| `app/models/flinks_connection.rb` | Encrypted tokens, belongs_to :user |
+| `app/services/flinks/client.rb` | HTTP client for Flinks API |
+| `app/services/flinks/errors.rb` | Error classes |
+| `app/services/flinks/transaction_importer.rb` | Transform + insert |
+| `app/jobs/flinks_import_job.rb` | Recurring sync job |
+| `config/recurring.yml` | Solid Queue schedule |
+| `app/graphql/types/flinks_connection_type.rb` | GQL type |
+| `app/graphql/types/flinks_import_status_type.rb` | GQL type |
+| `app/graphql/mutations/create_flinks_connection.rb` | Store connection |
+| `app/graphql/mutations/trigger_flinks_import.rb` | On-demand sync |
+| `app/graphql/mutations/delete_flinks_connection.rb` | Remove connection |
+| `spec/services/flinks/*_spec.rb` | Client + importer tests |
+| `lib/tasks/admin.rake` | Seed admin user + backfill |
+
+### Modified files (banking)
+| File | Change |
+|------|--------|
+| `Gemfile` | Add `solid_queue`, `vcr`, `webmock`; uncomment `bcrypt` |
+| `config/application.rb` | Uncomment `active_job/railtie` |
+| `config/routes.rb` | Auth routes (generated), registration route, Flinks callback |
+| `config/environments/production.rb` | `queue_adapter = :solid_queue` |
+| `config/deploy.yml` | Add `SOLID_QUEUE_IN_PUMA` env |
+| `app/controllers/application_controller.rb` | Include `Authentication` concern (generated) |
+| `app/controllers/graphql_controller.rb` | Pass `Current.user` to context |
+| `app/controllers/credit_card_transactions_controller.rb` | Scope through user |
+| `app/graphql/types/query_type.rb` | Scope queries through user |
+| `app/graphql/types/mutation_type.rb` | Add new mutations |
+| `app/graphql/mutations/create_note.rb` | Verify ownership |
+| `app/graphql/mutations/update_credit_card_transaction.rb` | Verify ownership |
+| `config/initializers/cors.rb` | Lock down origins |
+
+### New files (banking-react-apollo)
+| File | Purpose |
+|------|---------|
+| `src/components/LoginPage.jsx` | Login form (POST /session) |
+| `src/components/RegisterPage.jsx` | Registration form (POST /registration) |
+| `src/hooks/useAuth.js` | Auth context — login, register, logout, token in localStorage |
+| `src/components/FlinksConnect.jsx` | Bank connection widget |
+| `src/components/ImportStatus.jsx` | Sync status + manual trigger |
+
+### Modified files (banking-react-apollo)
+| File | Change |
+|------|--------|
+| `package.json` | Add `react-router-dom` |
+| `src/index.jsx` | Apollo auth link, router setup |
+| `src/components/App.jsx` | Protected routes, import status |
+| `src/components/AppNavbar.jsx` | User email, logout, settings |
+
+---
+
+## Verification
+
+1. **Auth:** Register user via curl, login, use session token to query GraphQL — verify scoped results
+2. **Isolation:** Create two users, import transactions for each, verify they only see their own
+3. **Backfill:** Run admin rake task, verify all existing transactions have `user_id`
+4. **Dedup:** Run Flinks import twice, verify no duplicate transactions
+5. **Recurring:** Check Solid Queue logs for scheduled 6am runs
+6. **Frontend:** Login flow, Flinks Connect widget, transaction list loads, import status shows

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,0 +1,25 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+<% password_digest = BCrypt::Password.create("password") %>
+
+# == Schema Information
+#
+# Table name: users
+#
+#  id              :bigint           not null, primary key
+#  email_address   :string           not null
+#  password_digest :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email_address  (email_address) UNIQUE
+#
+one:
+  email_address: one@example.com
+  password_digest: <%= password_digest %>
+
+two:
+  email_address: two@example.com
+  password_digest: <%= password_digest %>

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Auth endpoints", type: :request do
+  let(:allowed_origin) { ENV["CORS_ORIGINS"] || "http://localhost:3000" }
+
+  describe "POST /registration" do
+    it "creates a user and sets a session cookie" do
+      post "/registration",
+        params: { email_address: "new@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      expect(response).to have_http_status(:created)
+      expect(response.cookies["session_id"]).to be_present
+      body = JSON.parse(response.body)
+      expect(body["user"]["email_address"]).to eq("new@example.com")
+      expect(body["user"]).not_to have_key("password_digest")
+    end
+
+    it "returns 422 for duplicate email" do
+      User.create!(email_address: "dupe@example.com", password: "password123")
+      post "/registration",
+        params: { email_address: "dupe@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to be_present
+    end
+
+    it "returns 422 for missing email" do
+      post "/registration",
+        params: { email_address: "", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "POST /session" do
+    before do
+      User.create!(email_address: "user@example.com", password: "password123")
+    end
+
+    it "returns a session cookie for valid credentials" do
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      expect(response).to have_http_status(:created)
+      expect(response.cookies["session_id"]).to be_present
+      body = JSON.parse(response.body)
+      expect(body["user"]["email_address"]).to eq("user@example.com")
+    end
+
+    it "returns 401 for wrong password" do
+      post "/session",
+        params: { email_address: "user@example.com", password: "wrong" },
+        headers: { "Origin" => allowed_origin }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 for non-existent email" do
+      post "/session",
+        params: { email_address: "nobody@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /session" do
+    it "returns the current user when authenticated" do
+      User.create!(email_address: "user@example.com", password: "password123")
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      get "/session"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["user"]["email_address"]).to eq("user@example.com")
+    end
+
+    it "returns 401 when not authenticated" do
+      get "/session"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "DELETE /session" do
+    it "invalidates the session" do
+      User.create!(email_address: "user@example.com", password: "password123")
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      delete "/session", headers: { "Origin" => allowed_origin }
+      expect(response).to have_http_status(:ok)
+
+      get "/credit_card_transactions"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "Cookie authentication" do
+    it "returns 401 when accessing a protected endpoint without a cookie" do
+      get "/credit_card_transactions"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "allows access after login" do
+      User.create!(email_address: "user@example.com", password: "password123")
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      get "/credit_card_transactions"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "CSRF protection" do
+    it "rejects POST requests without an Origin header" do
+      User.create!(email_address: "user@example.com", password: "password123")
+      post "/session", params: { email_address: "user@example.com", password: "password123" }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "rejects POST requests from a foreign origin" do
+      User.create!(email_address: "user@example.com", password: "password123")
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => "https://evil.com" }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "allows GET requests without an Origin header" do
+      User.create!(email_address: "user@example.com", password: "password123")
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      get "/credit_card_transactions"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "Session expiry" do
+    it "rejects sessions older than 30 days" do
+      user = User.create!(email_address: "user@example.com", password: "password123")
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      # Age the session beyond 30 days
+      user.sessions.update_all(created_at: 31.days.ago)
+
+      get "/session"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "allows sessions within 30 days" do
+      User.create!(email_address: "user@example.com", password: "password123")
+      post "/session",
+        params: { email_address: "user@example.com", password: "password123" },
+        headers: { "Origin" => allowed_origin }
+
+      get "/session"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Auth endpoints", type: :request do
-  let(:allowed_origin) { ENV["CORS_ORIGINS"] || "http://localhost:3000" }
+  let(:allowed_origin) { ENV["CORS_ORIGINS"] || "http://localhost:3001" }
 
   describe "POST /registration" do
     it "creates a user and sets a session cookie" do

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe "Auth endpoints", type: :request do
 
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it "returns 422 for password shorter than 8 characters" do
+      post "/registration",
+        params: { email_address: "short@example.com", password: "abc" },
+        headers: { "Origin" => allowed_origin }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"].join).to match(/too short/i)
+    end
   end
 
   describe "POST /session" do


### PR DESCRIPTION
## Summary
- Rails 8 authentication generator adapted for API-only mode with httpOnly signed cookies
- Registration endpoint (`POST /registration`), login (`POST /session`), logout (`DELETE /session`), session check (`GET /session`)
- CSRF protection via Origin header verification
- CORS `credentials: true` with configurable origin (defaults to `localhost:3001`)
- 30-day session expiry (server-side + cookie)
- Minimum 8-character password, rate-limited registration
- Cookie middleware added back for API-only app

## Test plan
- [ ] Register a new user, verify session cookie is set
- [ ] Login, verify `GET /session` returns user
- [ ] Logout, verify session is invalidated
- [ ] Verify CSRF: POST without Origin header returns 403
- [ ] Verify expired sessions return 401

**Stack:** PR1 → PR2 → PR3 (frontend) → PR4 → PR5 → PR6 (frontend)