### PR TITLE
PR2: Per-user transaction isolation

### DIFF
--- a/app/controllers/credit_card_transactions_controller.rb
+++ b/app/controllers/credit_card_transactions_controller.rb
@@ -4,28 +4,31 @@
 class CreditCardTransactionsController < ApplicationController
   # @rbs return: void
   def index
-    transactions = CreditCardTransaction.includes(:credit_transaction).order(tx_date: :desc).limit(1000)
+    transactions = user_transactions.includes(:credit_transaction).order(tx_date: :desc).limit(1000)
     render json: CreditCardTransactionSerializer.new(transactions).serializable_hash
   end
 
   # @rbs return: void
   def debits
-    debits = CreditCardTransaction.debit.order(tx_date: :desc).limit(100)
-
+    debits = user_transactions.debit.order(tx_date: :desc).limit(100)
     render json: CreditCardTransactionSerializer.new(debits).serializable_hash
   end
 
   # @rbs return: void
   def debits_outstanding
-    debits = CreditCardTransaction.debit.without_credit.order(tx_date: :desc).limit(100)
-
+    debits = user_transactions.debit.without_credit.order(tx_date: :desc).limit(100)
     render json: CreditCardTransactionSerializer.new(debits).serializable_hash
   end
 
   # @rbs return: void
   def debits_with_credits
-    debits = CreditCardTransaction.debit.with_credit.includes(:credit_transaction).order(tx_date: :desc).limit(100)
-
+    debits = user_transactions.debit.with_credit.includes(:credit_transaction).order(tx_date: :desc).limit(100)
     render json: CreditCardTransactionSerializer.new(debits, { include: [:credit_transaction] }).serializable_hash
+  end
+
+  private
+
+  def user_transactions
+    Current.user.credit_card_transactions
   end
 end

--- a/app/graphql/banking_schema.rb
+++ b/app/graphql/banking_schema.rb
@@ -4,5 +4,8 @@ class BankingSchema < GraphQL::Schema
 
   use GraphQL::Batch
 
+  max_depth 10
+  max_complexity 200
+
   disable_introspection_entry_points if Rails.env.production?
 end

--- a/app/graphql/banking_schema.rb
+++ b/app/graphql/banking_schema.rb
@@ -3,4 +3,6 @@ class BankingSchema < GraphQL::Schema
   query(Types::QueryType)
 
   use GraphQL::Batch
+
+  disable_introspection_entry_points if Rails.env.production?
 end

--- a/app/graphql/mutations/create_note.rb
+++ b/app/graphql/mutations/create_note.rb
@@ -9,6 +9,9 @@ module Mutations
     field :errors, [String], null: false
 
     def resolve(detail:, credit_card_transaction_id:)
+      # Verify the transaction belongs to the current user
+      context[:current_user].credit_card_transactions.find_by!(id: credit_card_transaction_id)
+
       Note.upsert(
         {
           detail: detail,

--- a/app/graphql/mutations/update_credit_card_transaction.rb
+++ b/app/graphql/mutations/update_credit_card_transaction.rb
@@ -10,7 +10,7 @@ module Mutations
     field :errors, [String], null: false
 
     def resolve(note_detail:, note_id: nil, id:)
-      tx = CreditCardTransaction.find_by!(id: id)
+      tx = context[:current_user].credit_card_transactions.find_by!(id: id)
       if tx.update(note_attributes: { detail: note_detail, id: note_id })
         {
           credit_card_transaction: tx,

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,7 +11,7 @@ module Types
     end
 
     def credit_card_transactions(**options)
-      scope = CreditCardTransaction.where(tx_date: 12.months.ago..).order(options[:sort])
+      scope = context[:current_user].credit_card_transactions.where(tx_date: 12.months.ago..).order(options[:sort])
       scope = scope.without_notes unless options[:show_annotated]
       scope = scope.debit unless options[:show_credits]
 
@@ -22,7 +22,8 @@ module Types
       description: 'Returns a list of notes'
 
     def notes
-      Note.all
+      Note.joins(:credit_card_transaction)
+          .where(credit_card_transactions: { user_id: context[:current_user].id })
     end
   end
 end

--- a/app/models/credit_card_transaction.rb
+++ b/app/models/credit_card_transaction.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 class CreditCardTransaction < ApplicationRecord
+  belongs_to :user
   has_one :debit_specific_credit, foreign_key: :debit_id
   has_one :credit_transaction, through: :debit_specific_credit, source: :credit
 
@@ -62,9 +63,15 @@ end
 #  tx_date     :date
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #
-#  credit_card_transactions_credits_unique_key  (tx_date,details,credit) UNIQUE WHERE (debit IS NULL)
-#  credit_card_transactions_debits_unique_key   (tx_date,details,debit) UNIQUE WHERE (credit IS NULL)
+#  credit_card_transactions_credits_unique_key  (user_id,tx_date,details,credit) UNIQUE WHERE (debit IS NULL)
+#  credit_card_transactions_debits_unique_key   (user_id,tx_date,details,debit) UNIQUE WHERE (credit IS NULL)
+#  index_credit_card_transactions_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
+  has_many :credit_card_transactions, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 

--- a/app/serializers/credit_card_transaction_serializer.rb
+++ b/app/serializers/credit_card_transaction_serializer.rb
@@ -12,11 +12,17 @@
 #  tx_date     :date
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #
-#  credit_card_transactions_credits_unique_key  (tx_date,details,credit) UNIQUE WHERE (debit IS NULL)
-#  credit_card_transactions_debits_unique_key   (tx_date,details,debit) UNIQUE WHERE (credit IS NULL)
+#  credit_card_transactions_credits_unique_key  (user_id,tx_date,details,credit) UNIQUE WHERE (debit IS NULL)
+#  credit_card_transactions_debits_unique_key   (user_id,tx_date,details,debit) UNIQUE WHERE (credit IS NULL)
+#  index_credit_card_transactions_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 class CreditCardTransactionSerializer
   include FastJsonapi::ObjectSerializer

--- a/db/migrate/20260414161031_add_user_id_to_credit_card_transactions.rb
+++ b/db/migrate/20260414161031_add_user_id_to_credit_card_transactions.rb
@@ -1,0 +1,46 @@
+class AddUserIdToCreditCardTransactions < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :credit_card_transactions, :user, null: true, foreign_key: true
+
+    if CreditCardTransaction.unscoped.exists?
+      password = ENV.fetch("ADMIN_PASSWORD") { raise "Set ADMIN_PASSWORD env var to run this migration" }
+      digest = BCrypt::Password.create(password)
+      execute <<~SQL
+        INSERT INTO users (email_address, password_digest, created_at, updated_at)
+        VALUES ('ilia@lobsanov.com', '#{digest}', NOW(), NOW())
+        ON CONFLICT (email_address) DO NOTHING
+      SQL
+      execute <<~SQL
+        UPDATE credit_card_transactions
+        SET user_id = (SELECT id FROM users WHERE email_address = 'ilia@lobsanov.com')
+        WHERE user_id IS NULL
+      SQL
+    end
+
+    change_column_null :credit_card_transactions, :user_id, false
+
+    remove_index :credit_card_transactions, name: :credit_card_transactions_debits_unique_key
+    remove_index :credit_card_transactions, name: :credit_card_transactions_credits_unique_key
+
+    add_index :credit_card_transactions, [:user_id, :tx_date, :details, :debit],
+      unique: true, where: "credit IS NULL",
+      name: "credit_card_transactions_debits_unique_key"
+    add_index :credit_card_transactions, [:user_id, :tx_date, :details, :credit],
+      unique: true, where: "debit IS NULL",
+      name: "credit_card_transactions_credits_unique_key"
+  end
+
+  def down
+    remove_index :credit_card_transactions, name: :credit_card_transactions_debits_unique_key
+    remove_index :credit_card_transactions, name: :credit_card_transactions_credits_unique_key
+
+    add_index :credit_card_transactions, [:tx_date, :details, :debit],
+      unique: true, where: "credit IS NULL",
+      name: "credit_card_transactions_debits_unique_key"
+    add_index :credit_card_transactions, [:tx_date, :details, :credit],
+      unique: true, where: "debit IS NULL",
+      name: "credit_card_transactions_credits_unique_key"
+
+    remove_reference :credit_card_transactions, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_160042) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_14_161031) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,8 +22,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_160042) do
     t.text "details"
     t.date "tx_date"
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.index ["tx_date", "details", "credit"], name: "credit_card_transactions_credits_unique_key", unique: true, where: "(debit IS NULL)"
-    t.index ["tx_date", "details", "debit"], name: "credit_card_transactions_debits_unique_key", unique: true, where: "(credit IS NULL)"
+    t.bigint "user_id", null: false
+    t.index ["user_id", "tx_date", "details", "credit"], name: "credit_card_transactions_credits_unique_key", unique: true, where: "(debit IS NULL)"
+    t.index ["user_id", "tx_date", "details", "debit"], name: "credit_card_transactions_debits_unique_key", unique: true, where: "(credit IS NULL)"
+    t.index ["user_id"], name: "index_credit_card_transactions_on_user_id"
   end
 
   create_table "credits_debits", force: :cascade do |t|
@@ -61,6 +63,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_160042) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "credit_card_transactions", "users"
   add_foreign_key "notes", "credit_card_transactions"
   add_foreign_key "sessions", "users"
 end

--- a/docs/flinks-auto-import-progress.md
+++ b/docs/flinks-auto-import-progress.md
@@ -1,0 +1,96 @@
+# Flinks Auto-Import — Implementation Progress
+
+## PR Stack
+
+```
+main
+ └─ PR1: feat/user-auth-backend        ✅ done
+     └─ PR2: feat/transaction-isolation ✅ done
+         └─ PR3: feat/auth-frontend     ✅ done (banking-react-apollo repo)
+             └─ PR4: feat/flinks-connection         ⬜ not started
+                 └─ PR5: feat/flinks-import-pipeline ⬜ not started
+                     └─ PR6: feat/flinks-frontend    ⬜ not started
+```
+
+## PR1: User auth backend — `feat/user-auth-backend`
+**Repo:** banking | **Status:** complete | **Tests:** 16 pass
+
+- [x] Rails 8 auth generator (User, Session, Current models)
+- [x] Adapted for API-only: JSON responses, httpOnly signed cookies, cookie middleware
+- [x] RegistrationsController (`POST /registration`)
+- [x] SessionsController with `GET /session` (whoami), `POST /session` (login), `DELETE /session` (logout)
+- [x] CSRF protection via Origin header verification (`verify_origin` before_action)
+- [x] CORS `credentials: true` with specific origin
+- [x] 30-day session expiry (server-side check + cookie `expires`)
+- [x] Request specs: registration, login, logout, session check, cookie auth, CSRF (3 tests), session expiry (2 tests)
+
+## PR2: Transaction isolation — `feat/transaction-isolation`
+**Repo:** banking | **Status:** complete | **Tests:** 43 pass (cumulative)
+
+- [x] Migration: `user_id` on `credit_card_transactions` (NOT NULL, FK)
+- [x] Backfill existing data to `ilia@lobsanov.com` (migration requires `ADMIN_PASSWORD` env var)
+- [x] User-scoped unique indexes (replacing global ones)
+- [x] `belongs_to :user` on CreditCardTransaction, `has_many :credit_card_transactions` on User
+- [x] Scoped GraphQL queries (`creditCardTransactions`, `notes`) through `context[:current_user]`
+- [x] Scoped mutations (`updateCreditCardTransaction`, `createNote`) — ownership verified
+- [x] Scoped REST controller through `Current.user.credit_card_transactions`
+- [x] Updated all existing specs to pass `current_user` in context
+- [x] Isolation specs: user A can't see user B's data (GraphQL + REST)
+- [x] Mutation isolation specs: can't modify another user's transactions
+
+## PR3: Auth frontend — `feat/auth-frontend`
+**Repo:** banking-react-apollo | **Status:** complete | **Tests:** 10 pass
+
+- [x] `useAuth` hook: cookie-based auth, `GET /session` on mount, login/register/logout
+- [x] `useAuth` tests (5 tests): session check, login success/failure, logout
+- [x] `LoginPage` component
+- [x] `RegisterPage` component
+- [x] `App.jsx` with react-router-dom: `ProtectedRoute`, `PublicRoute`
+- [x] `AppNavbar` with user email + logout
+- [x] Apollo Client `credentials: 'include'`
+- [x] Vitest + @testing-library/react setup
+
+## PR4: Flinks connection — `feat/flinks-connection`
+**Repo:** banking + banking-react-apollo | **Status:** not started
+
+- [ ] Migration: `flinks_connections` table with encrypted columns
+- [ ] `FlinksConnection` model with `encrypts :login_id, :request_id`
+- [ ] `Flinks::Client` HTTP wrapper (VCR cassettes for tests)
+- [ ] `Flinks::Errors` classes
+- [ ] GraphQL mutations: `createFlinksConnection`, `deleteFlinksConnection`
+- [ ] `FlinksConnect` frontend component (iframe widget)
+- [ ] Specs
+
+## PR5: Flinks import pipeline — `feat/flinks-import-pipeline`
+**Repo:** banking | **Status:** not started
+
+- [ ] `Flinks::TransactionImporter` service
+- [ ] `FlinksImportJob` (Solid Queue recurring)
+- [ ] `config/recurring.yml` — daily 6am ET
+- [ ] Enable Solid Queue (uncomment `active_job/railtie`, add gem, configure)
+- [ ] GraphQL: `flinksImportStatus` query, `triggerFlinksImport` mutation (scoped to current user)
+- [ ] Specs (VCR + real DB)
+
+## PR6: Flinks frontend — `feat/flinks-frontend`
+**Repo:** banking-react-apollo | **Status:** not started
+
+- [ ] `ImportStatus` component (last sync, "Sync Now" button)
+- [ ] Connection management UI (list, disconnect)
+- [ ] Integration into dashboard
+
+## Security Audit Fixes
+
+| Finding | Severity | Status | PR |
+|---------|----------|--------|----|
+| CSRF via Origin verification | CRITICAL | ✅ fixed | PR1 |
+| Sessions never expire | HIGH | ✅ fixed | PR1 |
+| Hardcoded "changeme" password | HIGH | ✅ fixed | PR2 |
+| No minimum password length | MEDIUM | ⬜ todo | PR1 |
+| No registration rate limiting | MEDIUM | ⬜ todo | PR1 |
+| GraphQL introspection in prod | MEDIUM | ⬜ todo | PR2 |
+| GraphQL depth/complexity limits | MEDIUM | ⬜ todo | PR2 |
+| Passwords route overly broad | MEDIUM | ⬜ todo | PR1 |
+| Flinks import scoped to user | MEDIUM | ⬜ todo | PR5 |
+| Unused token column on sessions | LOW | ⬜ todo | PR1 |
+| config.hosts not configured | LOW | ⬜ todo | PR1 |
+| GraphQL RecordNotFound handling | LOW | ⬜ todo | PR2 |

--- a/docs/flinks-auto-import-progress.md
+++ b/docs/flinks-auto-import-progress.md
@@ -85,11 +85,11 @@ main
 | CSRF via Origin verification | CRITICAL | ✅ fixed | PR1 |
 | Sessions never expire | HIGH | ✅ fixed | PR1 |
 | Hardcoded "changeme" password | HIGH | ✅ fixed | PR2 |
-| No minimum password length | MEDIUM | ⬜ todo | PR1 |
-| No registration rate limiting | MEDIUM | ⬜ todo | PR1 |
-| GraphQL introspection in prod | MEDIUM | ⬜ todo | PR2 |
-| GraphQL depth/complexity limits | MEDIUM | ⬜ todo | PR2 |
-| Passwords route overly broad | MEDIUM | ⬜ todo | PR1 |
+| No minimum password length | MEDIUM | ✅ fixed | PR1 |
+| No registration rate limiting | MEDIUM | ✅ fixed | PR1 |
+| GraphQL introspection in prod | MEDIUM | ✅ fixed | PR2 |
+| GraphQL depth/complexity limits | MEDIUM | ✅ fixed | PR2 |
+| Passwords route overly broad | MEDIUM | deferred | PR1 |
 | Flinks import scoped to user | MEDIUM | ⬜ todo | PR5 |
 | Unused token column on sessions | LOW | ⬜ todo | PR1 |
 | config.hosts not configured | LOW | ⬜ todo | PR1 |

--- a/docs/flinks-auto-import-with-auth.md
+++ b/docs/flinks-auto-import-with-auth.md
@@ -3,6 +3,8 @@
 ## Conventions
 
 - **No co-authored-by lines** in commit messages or PR descriptions
+- **No two-phase deploys** during this feature's implementation — migrations and dependent code ship together in each PR
+- **httpOnly cookies for auth** — no localStorage, no Bearer tokens, no JWT. The browser handles cookie storage and sending via `credentials: 'include'`
 
 ## Context
 
@@ -55,57 +57,41 @@ Three projects are involved:
 
 ## Part 1: User Authentication
 
-### Approach: Rails 8 built-in authentication generator (`--api`)
+### Approach: Rails 8 built-in auth generator + httpOnly cookies
 
-**Why the built-in generator:** Rails 8.1 ships with `bin/rails generate authentication --api` which creates a complete token-based auth system. It uses server-side session tokens (stored in a `sessions` table) sent via `Authorization: Bearer <token>` headers — works identically with Apollo Client. No custom JWT code to maintain.
+**Why the built-in generator:** Rails 8.1 ships with `bin/rails generate authentication` which creates a complete session-based auth system. We adapt it for API-only mode with JSON responses.
 
-**Why not JWT:** The generator provides revocable tokens (delete the session row), session tracking (IP, user agent), and password reset — all out of the box. JWT requires a custom implementation, can't be revoked without a blocklist, and needs secret key management.
+**Why httpOnly cookies (not Bearer tokens or JWT):** Production uses HTTPS (Kamal proxy terminates SSL), so `SameSite=None; Secure` cookies work cross-origin. httpOnly cookies can't be read by JavaScript, eliminating XSS token theft. The browser handles cookie storage and sending automatically — no localStorage, no token management in the frontend.
 
 **Why not Devise:** Overkill for this app — one user table, no OAuth, no confirmable/lockable.
 
-### What the generator creates
+### What the generator creates (adapted for API-only)
 
 | File | Purpose |
 |------|---------|
 | `app/models/user.rb` | `has_secure_password`, `has_many :sessions`, `normalizes :email_address` |
-| `app/models/session.rb` | Token-based session record (user_id, ip_address, user_agent) |
+| `app/models/session.rb` | Session record (user_id, ip_address, user_agent, token) |
 | `app/models/current.rb` | Thread-local `Current.user` / `Current.session` |
-| `app/controllers/concerns/authentication.rb` | `require_authentication`, `current_user`, token lookup via `Authorization: Bearer` |
-| `app/controllers/sessions_controller.rb` | `POST /session` (login), `DELETE /session` (logout) |
-| `app/controllers/passwords_controller.rb` | Password reset endpoints |
+| `app/controllers/concerns/authentication.rb` | `require_authentication`, session lookup via signed `session_id` cookie, returns 401 JSON (not redirect) |
+| `app/controllers/sessions_controller.rb` | `GET /session` (whoami), `POST /session` (login), `DELETE /session` (logout) — all JSON |
+| `app/controllers/passwords_controller.rb` | Password reset (JSON) |
 | `db/migrate/*_create_users.rb` | `email_address` (unique), `password_digest` |
-| `db/migrate/*_create_sessions.rb` | `user_id`, `ip_address`, `user_agent` |
+| `db/migrate/*_create_sessions.rb` | `user_id`, `token`, `ip_address`, `user_agent` |
 
 ### What we add on top
 
 | File | Purpose |
 |------|---------|
-| `app/controllers/registrations_controller.rb` | `POST /registration` — create user + session, return token |
+| `app/controllers/registrations_controller.rb` | `POST /registration` — create user + session, set cookie, return JSON |
+| `config/application.rb` | Add `ActionDispatch::Cookies` and `ActionDispatch::Session::CookieStore` middleware (stripped by `api_only`) |
+| `app/controllers/application_controller.rb` | Include `ActionController::Cookies` |
+| `config/initializers/cors.rb` | `credentials: true`, specific origin (not wildcard) |
 
-The generator does not include registration. We add a single controller for that.
+### Cookie details
 
-### Database tables
-
-```sql
--- Created by generator
-CREATE TABLE users (
-  id               bigserial PRIMARY KEY,
-  email_address    varchar NOT NULL,
-  password_digest  varchar NOT NULL,
-  created_at       timestamptz NOT NULL,
-  updated_at       timestamptz NOT NULL,
-  UNIQUE(email_address)
-);
-
-CREATE TABLE sessions (
-  id         bigserial PRIMARY KEY,
-  user_id    bigint NOT NULL REFERENCES users(id),
-  ip_address varchar,
-  user_agent varchar,
-  created_at timestamptz NOT NULL,
-  updated_at timestamptz NOT NULL
-);
-```
+- `cookies.signed.permanent[:session_id]` — signed by Rails (tamper-proof), httpOnly (no JS access), Secure in production, `SameSite=None` in production (cross-origin)
+- Session lookup: `Session.find_by(id: cookies.signed[:session_id])`
+- Frontend checks auth status via `GET /session` on page load (returns 200 with user or 401)
 
 ### Auth in GraphQL + REST
 
@@ -113,36 +99,25 @@ CREATE TABLE sessions (
 - `GraphqlController#execute` passes `Current.user` into GraphQL context
 - All resolvers scope queries through `context[:current_user]`
 - All REST controller actions scope through `Current.user`
-- Missing/invalid token → 401 response (handled by the concern)
+- Missing/invalid cookie → 401 response (handled by the concern)
 
 ### Frontend files
 
 | File | Purpose |
 |------|---------|
-| `src/components/LoginPage.jsx` | Email + password form, stores session token in localStorage |
+| `src/components/LoginPage.jsx` | Email + password form |
 | `src/components/RegisterPage.jsx` | Registration form |
-| `src/hooks/useAuth.js` | Auth state context — `login()`, `logout()`, `isAuthenticated` |
+| `src/hooks/useAuth.jsx` | Auth state via `GET /session` check — `login()`, `register()`, `logout()`, `isAuthenticated`, `user`, `loading` |
 
-**Apollo Client change** (`src/index.jsx`):
+**Apollo Client change** (`src/index.jsx`) — just `credentials: 'include'`, no auth headers:
 ```js
-import { setContext } from '@apollo/client/link/context';
-
-const authLink = setContext((_, { headers }) => ({
-  headers: {
-    ...headers,
-    authorization: localStorage.getItem('token')
-      ? `Bearer ${localStorage.getItem('token')}`
-      : '',
-  },
-}));
-
-const client = new ApolloClient({
-  link: authLink.concat(httpLink),
-  cache: new InMemoryCache(),
+const httpLink = new HttpLink({
+  uri: import.meta.env.VITE_GRAPHQL_URI,
+  credentials: 'include',
 });
 ```
 
-**Routing:** Add `react-router-dom` for login/register/dashboard pages. Unauthenticated users → login page. 401 from API → clear token, redirect to login.
+**Routing:** `react-router-dom` with `ProtectedRoute` (redirect to `/login` if unauthenticated) and `PublicRoute` (redirect to `/` if already authenticated).
 
 ---
 
@@ -367,9 +342,12 @@ Tests first (red):
 
 Then implementation (green):
 3. Run `bin/rails generate authentication` — creates User, Session, Current models, Authentication concern, SessionsController, PasswordsController, migrations
-4. `app/controllers/registrations_controller.rb` — `POST /registration` (generator doesn't include signup)
-5. `config/routes.rb` — add `resource :registration, only: :create`
-6. Pass `Current.user` into GraphQL context in `graphql_controller.rb`
+4. Adapt generated code for API-only + httpOnly cookies: JSON responses (not redirects), `cookies.signed[:session_id]` lookup, add cookie middleware to `config/application.rb`, include `ActionController::Cookies` in ApplicationController
+5. `app/controllers/registrations_controller.rb` — `POST /registration` (generator doesn't include signup)
+6. `app/controllers/sessions_controller.rb` — add `GET /session` (whoami) action
+7. `config/routes.rb` — add `resource :registration, only: :create`, add `:show` to session
+8. `config/initializers/cors.rb` — `credentials: true`, specific origin
+9. Pass `Current.user` into GraphQL context in `graphql_controller.rb`
 
 - **Deploy note:** Auth endpoints exist but nothing requires auth yet. Existing API continues to work unauthenticated.
 
@@ -395,24 +373,22 @@ Then implementation (green):
 14. Lock down CORS origins in `cors.rb`
 15. Update fixtures to include `user_id`
 
-- **Deploy note:** Two-phase — deploy migration + backfill first, then deploy auth enforcement. After this PR, the API requires a JWT.
+- **Deploy note:** After this PR, the API requires authentication via session cookie.
 
 ### PR3: `feat/auth-frontend` → `feat/transaction-isolation`
 **Login/register UI + protected routes (frontend)**
 
 Tests first (red):
-1. `src/hooks/useAuth.test.js` — login stores session token, logout calls DELETE /session and clears token, isAuthenticated reflects state
-2. `src/components/LoginPage.test.jsx` — renders form, submits credentials to POST /session, shows error on failure, redirects on success
-3. `src/components/RegisterPage.test.jsx` — renders form, submits to POST /registration, shows error on duplicate email
+1. `src/hooks/useAuth.test.jsx` — session check on mount sets isAuthenticated; login sets user on success; login throws on invalid credentials; logout clears user
 
 Then implementation (green):
-4. Add `react-router-dom`, `@testing-library/react` dependencies
-5. `src/hooks/useAuth.js` — auth context, `login()` (POST /session), `register()` (POST /registration), `logout()` (DELETE /session), `isAuthenticated`
-6. `src/components/LoginPage.jsx` — email + password form
-7. `src/components/RegisterPage.jsx` — registration form
-8. `src/index.jsx` — Apollo `setContext` auth link with Bearer token, error link for 401 → redirect
-9. `src/components/App.jsx` — route setup, protected routes
-10. `src/components/AppNavbar.jsx` — user email display, logout button
+2. Add `react-router-dom`, `@testing-library/react` dependencies
+3. `src/hooks/useAuth.jsx` — auth state via `GET /session` on mount, `login()`, `register()`, `logout()` with `credentials: 'include'`, no localStorage
+4. `src/components/LoginPage.jsx` — email + password form
+5. `src/components/RegisterPage.jsx` — registration form
+6. `src/index.jsx` — Apollo HttpLink with `credentials: 'include'`, BrowserRouter, AuthProvider wrapping
+7. `src/components/App.jsx` — ProtectedRoute/PublicRoute wrappers, react-router-dom Routes
+8. `src/components/AppNavbar.jsx` — user email display, logout button
 
 - **Deploy note:** Can deploy frontend before or after PR2, but the app will require login once both are live.
 
@@ -508,7 +484,7 @@ Then implementation (green):
 ### Modified files (banking)
 | File | Change |
 |------|--------|
-| `Gemfile` | Add `solid_queue`, `vcr`, `webmock`; uncomment `bcrypt` |
+| `Gemfile` | Add `solid_queue`, `vcr`, `webmock`, `bcrypt` (added by auth generator) |
 | `config/application.rb` | Uncomment `active_job/railtie` |
 | `config/routes.rb` | Auth routes (generated), registration route, Flinks callback |
 | `config/environments/production.rb` | `queue_adapter = :solid_queue` |
@@ -527,7 +503,7 @@ Then implementation (green):
 |------|---------|
 | `src/components/LoginPage.jsx` | Login form (POST /session) |
 | `src/components/RegisterPage.jsx` | Registration form (POST /registration) |
-| `src/hooks/useAuth.js` | Auth context — login, register, logout, token in localStorage |
+| `src/hooks/useAuth.jsx` | Auth context — login, register, logout via httpOnly cookies (no localStorage) |
 | `src/components/FlinksConnect.jsx` | Bank connection widget |
 | `src/components/ImportStatus.jsx` | Sync status + manual trigger |
 
@@ -535,17 +511,92 @@ Then implementation (green):
 | File | Change |
 |------|--------|
 | `package.json` | Add `react-router-dom` |
-| `src/index.jsx` | Apollo auth link, router setup |
+| `src/index.jsx` | Apollo `credentials: 'include'`, BrowserRouter, AuthProvider |
 | `src/components/App.jsx` | Protected routes, import status |
 | `src/components/AppNavbar.jsx` | User email, logout, settings |
 
 ---
 
+## Security Audit Findings
+
+Address before shipping. Integrate fixes into the relevant PRs.
+
+### CRITICAL
+
+**CSRF with `SameSite=None` cookies.** CORS only prevents reading the response — it does not block the request. Any website can forge `POST /graphql` mutations and the browser attaches the session cookie. Fix: add Origin header verification as a `before_action` on `ApplicationController` — reject non-GET requests where `request.headers['Origin']` doesn't match the allowed origin.
+
+- File: `app/controllers/application_controller.rb`
+- Belongs in: PR1
+
+### HIGH
+
+**Sessions never expire.** `cookies.signed.permanent` sets a 20-year cookie and `find_session_by_cookie` has no TTL check. Fix: use a session-lifetime cookie (drop `permanent`), add server-side expiry check (e.g., `Session.where(created_at: 30.days.ago..)` in the lookup).
+
+- Files: `app/controllers/concerns/authentication.rb`, `app/models/session.rb`
+- Belongs in: PR1
+
+**Hardcoded "changeme" password in migration.** The bcrypt hash is committed to version control. Fix: change the admin user password immediately after deploy. For future seed data, use a rake task that reads from credentials or prompts for input.
+
+- File: `db/migrate/20260414161031_add_user_id_to_credit_card_transactions.rb`
+- Belongs in: PR2 (or manual post-deploy step)
+
+### MEDIUM
+
+**No minimum password length.** Users can register with a 1-character password. Fix: add `validates :password, length: { minimum: 8 }, if: -> { password.present? }` to User model.
+
+- File: `app/models/user.rb`
+- Belongs in: PR1
+
+**No rate limiting on registration.** `SessionsController` has rate limiting but `RegistrationsController` does not. Fix: add `rate_limit to: 5, within: 10.minutes, only: :create`.
+
+- File: `app/controllers/registrations_controller.rb`
+- Belongs in: PR1
+
+**GraphQL introspection enabled in production.** Full schema discoverable. Fix: add `disable_introspection_entry_points if Rails.env.production?` to schema.
+
+- File: `app/graphql/banking_schema.rb`
+- Belongs in: PR2
+
+**No GraphQL depth/complexity limits.** DoS vector. Fix: add `max_depth 10` and `max_complexity 200` to schema.
+
+- File: `app/graphql/banking_schema.rb`
+- Belongs in: PR2
+
+**Passwords route overly broad.** `resources :passwords` creates 7 routes, only `update` is implemented. Fix: restrict to `resource :password, only: [:update], param: :token`.
+
+- File: `config/routes.rb`
+- Belongs in: PR1
+
+**Flinks `triggerFlinksImport` must be scoped** to the current user's connections, not all active connections.
+
+- Belongs in: PR5
+
+### LOW
+
+**Unused `token` column on sessions.** `find_session_by_cookie` looks up by `id` via signed cookie, not by `token`. Remove the column or repurpose it.
+
+- File: `app/models/session.rb`, `db/migrate/*_create_sessions.rb`
+- Belongs in: PR1
+
+**`config.hosts` not configured in production.** Add `config.hosts = ["budgetr.nurey.com"]` for defense-in-depth.
+
+- File: `config/environments/production.rb`
+- Belongs in: PR1
+
+**GraphQL `RecordNotFound` handling.** `find_by!` in mutations may produce raw exception messages instead of clean GraphQL errors. Verify and add `rescue_from` if needed.
+
+- Files: `app/graphql/mutations/create_note.rb`, `app/graphql/mutations/update_credit_card_transaction.rb`
+- Belongs in: PR2
+
+---
+
 ## Verification
 
-1. **Auth:** Register user via curl, login, use session token to query GraphQL — verify scoped results
-2. **Isolation:** Create two users, import transactions for each, verify they only see their own
-3. **Backfill:** Run admin rake task, verify all existing transactions have `user_id`
-4. **Dedup:** Run Flinks import twice, verify no duplicate transactions
-5. **Recurring:** Check Solid Queue logs for scheduled 6am runs
-6. **Frontend:** Login flow, Flinks Connect widget, transaction list loads, import status shows
+1. **Auth:** Register user via curl, login, verify session cookie is set, `GET /session` returns user
+2. **CSRF:** Verify that a cross-origin POST without matching Origin header is rejected
+3. **Session expiry:** Verify that expired sessions return 401
+4. **Isolation:** Create two users, import transactions for each, verify they only see their own
+5. **Backfill:** Run admin rake task, verify all existing transactions have `user_id`
+6. **Dedup:** Run Flinks import twice, verify no duplicate transactions
+7. **Recurring:** Check Solid Queue logs for scheduled 6am runs
+8. **Frontend:** Login flow, Flinks Connect widget, transaction list loads, import status shows

--- a/spec/fixtures/credit_card_transactions.yml
+++ b/spec/fixtures/credit_card_transactions.yml
@@ -10,38 +10,49 @@
 #  tx_date     :date
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #
-#  credit_card_transactions_credits_unique_key  (tx_date,details,credit) UNIQUE WHERE (debit IS NULL)
-#  credit_card_transactions_debits_unique_key   (tx_date,details,debit) UNIQUE WHERE (credit IS NULL)
+#  credit_card_transactions_credits_unique_key  (user_id,tx_date,details,credit) UNIQUE WHERE (debit IS NULL)
+#  credit_card_transactions_debits_unique_key   (user_id,tx_date,details,debit) UNIQUE WHERE (credit IS NULL)
+#  index_credit_card_transactions_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 recent_debit:
   tx_date: <%= 2.months.ago.to_date %>
   details: "GROCERY STORE <%= SecureRandom.hex(4) %>"
   debit: 4599
   card_number: "1234"
+  user: alice
 
 annotated_debit:
   tx_date: <%= 3.months.ago.to_date %>
   details: "RESTAURANT DINNER <%= SecureRandom.hex(4) %>"
   debit: 8250
   card_number: "1234"
+  user: alice
 
 recent_credit:
   tx_date: <%= 1.month.ago.to_date %>
   details: "PAYMENT RECEIVED <%= SecureRandom.hex(4) %>"
   credit: 50000
   card_number: "1234"
+  user: alice
 
 boundary_debit:
   tx_date: <%= 12.months.ago.to_date %>
   details: "BOUNDARY PURCHASE <%= SecureRandom.hex(4) %>"
   debit: 1500
   card_number: "5678"
+  user: alice
 
 old_debit:
   tx_date: <%= 13.months.ago.to_date %>
   details: "OLD PURCHASE <%= SecureRandom.hex(4) %>"
   debit: 2000
   card_number: "5678"
+  user: alice

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,6 +1,4 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-<% password_digest = BCrypt::Password.create("password") %>
+<% password_digest = BCrypt::Password.create("password123") %>
 
 # == Schema Information
 #
@@ -16,10 +14,10 @@
 #
 #  index_users_on_email_address  (email_address) UNIQUE
 #
-one:
-  email_address: one@example.com
+alice:
+  email_address: "alice@example.com"
   password_digest: <%= password_digest %>
 
-two:
-  email_address: two@example.com
+bob:
+  email_address: "bob@example.com"
   password_digest: <%= password_digest %>

--- a/spec/graphql/mutations/create_note_mutation_spec.rb
+++ b/spec/graphql/mutations/create_note_mutation_spec.rb
@@ -3,7 +3,13 @@
 require "rails_helper"
 
 RSpec.describe "createNote mutation" do
-  fixtures :credit_card_transactions, :notes
+  fixtures :users, :credit_card_transactions, :notes
+
+  let(:current_user) { users(:alice) }
+
+  def execute_graphql(query, variables: {})
+    super(query, variables: variables, context: { current_user: current_user })
+  end
 
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/mutations/mutation_isolation_spec.rb
+++ b/spec/graphql/mutations/mutation_isolation_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "mutation isolation" do
+  fixtures :users, :credit_card_transactions, :notes
+
+  describe "updateCreditCardTransaction" do
+    let(:mutation) do
+      <<~GQL
+        mutation($id: ID!, $noteDetail: String!) {
+          updateCreditCardTransaction(id: $id, noteDetail: $noteDetail) {
+            creditCardTransaction { id }
+            errors
+          }
+        }
+      GQL
+    end
+
+    it "cannot update another user's transaction" do
+      bob = users(:bob)
+      alice_tx = credit_card_transactions(:recent_debit)  # belongs to alice
+
+      expect {
+        execute_graphql(mutation,
+          variables: { "id" => alice_tx.id.to_s, "noteDetail" => "hacked" },
+          context: { current_user: bob })
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe "createNote" do
+    let(:mutation) do
+      <<~GQL
+        mutation($creditCardTransactionId: ID!, $detail: String!) {
+          createNote(creditCardTransactionId: $creditCardTransactionId, detail: $detail) {
+            note { id detail }
+            errors
+          }
+        }
+      GQL
+    end
+
+    it "cannot annotate another user's transaction" do
+      bob = users(:bob)
+      alice_tx = credit_card_transactions(:recent_debit)
+
+      expect {
+        execute_graphql(mutation,
+          variables: { "creditCardTransactionId" => alice_tx.id.to_s, "detail" => "hacked" },
+          context: { current_user: bob })
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/graphql/mutations/update_credit_card_transaction_mutation_spec.rb
+++ b/spec/graphql/mutations/update_credit_card_transaction_mutation_spec.rb
@@ -3,7 +3,13 @@
 require "rails_helper"
 
 RSpec.describe "updateCreditCardTransaction mutation" do
-  fixtures :credit_card_transactions, :notes
+  fixtures :users, :credit_card_transactions, :notes
+
+  let(:current_user) { users(:alice) }
+
+  def execute_graphql(query, variables: {})
+    super(query, variables: variables, context: { current_user: current_user })
+  end
 
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/queries/credit_card_transactions_query_spec.rb
+++ b/spec/graphql/queries/credit_card_transactions_query_spec.rb
@@ -3,7 +3,13 @@
 require "rails_helper"
 
 RSpec.describe "creditCardTransactions query" do
-  fixtures :credit_card_transactions, :notes
+  fixtures :users, :credit_card_transactions, :notes
+
+  let(:current_user) { users(:alice) }
+
+  def execute_graphql(query, variables: {})
+    super(query, variables: variables, context: { current_user: current_user })
+  end
 
   let(:query) do
     <<~GQL

--- a/spec/graphql/queries/notes_query_spec.rb
+++ b/spec/graphql/queries/notes_query_spec.rb
@@ -3,7 +3,13 @@
 require "rails_helper"
 
 RSpec.describe "notes query" do
-  fixtures :credit_card_transactions, :notes
+  fixtures :users, :credit_card_transactions, :notes
+
+  let(:current_user) { users(:alice) }
+
+  def execute_graphql(query, variables: {})
+    super(query, variables: variables, context: { current_user: current_user })
+  end
 
   let(:query) do
     <<~GQL

--- a/spec/graphql/queries/transaction_isolation_spec.rb
+++ b/spec/graphql/queries/transaction_isolation_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "transaction isolation" do
+  fixtures :users, :credit_card_transactions, :notes
+
+  let(:query) do
+    <<~GQL
+      query {
+        creditCardTransactions {
+          id
+          details
+        }
+      }
+    GQL
+  end
+
+  it "returns only the current user's transactions" do
+    alice = users(:alice)
+    result = execute_graphql(query, context: { current_user: alice })
+    ids = result.dig("data", "creditCardTransactions").map { |t| t["id"].to_i }
+
+    alice_tx_ids = CreditCardTransaction.where(user: alice, tx_date: 12.months.ago..).pluck(:id)
+    bob_tx_ids = CreditCardTransaction.where(user: users(:bob)).pluck(:id)
+
+    expect(ids).to match_array(alice_tx_ids)
+    bob_tx_ids.each { |id| expect(ids).not_to include(id) }
+  end
+
+  it "returns empty when user has no transactions" do
+    bob = users(:bob)
+    result = execute_graphql(query, context: { current_user: bob })
+    transactions = result.dig("data", "creditCardTransactions")
+
+    expect(transactions).to eq([])
+  end
+end

--- a/spec/requests/transaction_isolation_spec.rb
+++ b/spec/requests/transaction_isolation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "REST transaction isolation", type: :request do
   def login_as(user)
     post "/session",
       params: { email_address: user.email_address, password: "password123" },
-      headers: { "Origin" => ENV["CORS_ORIGINS"] || "http://localhost:3000" }
+      headers: { "Origin" => ENV["CORS_ORIGINS"] || "http://localhost:3001" }
   end
 
   it "index returns only the current user's transactions" do

--- a/spec/requests/transaction_isolation_spec.rb
+++ b/spec/requests/transaction_isolation_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "REST transaction isolation", type: :request do
+  fixtures :users, :credit_card_transactions
+
+  def login_as(user)
+    post "/session",
+      params: { email_address: user.email_address, password: "password123" },
+      headers: { "Origin" => ENV["CORS_ORIGINS"] || "http://localhost:3000" }
+  end
+
+  it "index returns only the current user's transactions" do
+    alice = users(:alice)
+    login_as(alice)
+    get "/credit_card_transactions"
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    ids = body.dig("data").map { |t| t.dig("id").to_i }
+
+    alice_tx_ids = CreditCardTransaction.where(user: alice).pluck(:id)
+    expect(ids).to match_array(alice_tx_ids)
+  end
+
+  it "debits returns only the current user's debits" do
+    alice = users(:alice)
+    login_as(alice)
+    get "/credit_card_transactions/debits"
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    ids = body.dig("data").map { |t| t.dig("id").to_i }
+
+    bob_tx_ids = CreditCardTransaction.where(user: users(:bob)).pluck(:id)
+    bob_tx_ids.each { |id| expect(ids).not_to include(id) }
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `user_id` (NOT NULL, FK) to `credit_card_transactions` with backfill to `ilia@lobsanov.com`
- User-scoped unique indexes replace global ones
- All GraphQL queries, mutations, and REST controllers scoped through `current_user`
- Migration requires `ADMIN_PASSWORD` env var (no hardcoded passwords)
- GraphQL introspection disabled in production, depth/complexity limits added

## Test plan
- [ ] User A cannot see User B's transactions (GraphQL + REST)
- [ ] Cannot update/annotate another user's transactions
- [ ] Duplicate transactions for different users are allowed
- [ ] Existing data is backfilled to the admin user

**Stack:** PR1 → **PR2** → PR3 (frontend) → PR4 → PR5 → PR6 (frontend)